### PR TITLE
Fix misplaced docstrings in main() functions

### DIFF
--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -310,12 +310,6 @@ def print_summary(scores, train_result, improved):
 
 
 def main():
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
     """Orchestrate a single experiment: preprocess → train → evaluate → commit/revert.
 
     High-level flow:
@@ -327,6 +321,11 @@ def main():
          If no improvement → revert train.py to the last committed version.
       6. Attempt to register the model in the MLflow registry (keeps top-N only).
     """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     parser = argparse.ArgumentParser(description="AgentML Experiment Orchestrator")
     parser.add_argument("--force-prepare", action="store_true",
                         help="Re-run preprocessing even if splits exist")

--- a/src/select_model.py
+++ b/src/select_model.py
@@ -171,17 +171,17 @@ def promote_model(client, registry_name, rank):
 
 
 def main():
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
     """Entry point for the model selector CLI.
 
     Resolves the MLflow tracking URI (supporting both local paths and remote
     URIs), builds the registry name from the experiment name, then delegates
     to list_models() or promote_model() based on the supplied flags.
     """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     parser = argparse.ArgumentParser(description="AgentML Model Selector")
     parser.add_argument("--list", action="store_true",
                         help="List all registered models with metrics")


### PR DESCRIPTION
Fix misplaced docstrings in main() of run_experiment.py and select_model.py

- Move docstrings before logging.basicConfig() calls so Python treats them as actual docstrings

Closes #3