### PR TITLE
docs: add detailed docstrings to src/ (issue #8)

### DIFF
--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -89,7 +89,20 @@ def save_best_scores(scores, path=None):
 
 
 def run_prepare(config, force=False):
-    """Run the preprocessing pipeline."""
+    """Run the preprocessing pipeline (prepare.py) as a subprocess.
+
+    Skips execution if processed data already exists unless ``force=True``.
+
+    Args:
+        config (dict): Parsed YAML config from program.md (currently unused
+            but kept for future per-config caching logic).
+        force (bool): If True, re-run preprocessing even when
+            ``processed/data_splits.pkl`` already exists.
+
+    Returns:
+        bool: True if preprocessing succeeded (or was skipped), False if the
+            subprocess exited with a non-zero return code.
+    """
     processed_path = os.path.join(PROJECT_ROOT, "processed", "data_splits.pkl")
 
     if os.path.exists(processed_path) and not force:
@@ -151,7 +164,21 @@ def run_train(tracking_uri, run_id, experiment_name):
 
 
 def git_commit_train(model_name, val_score, metric_name, notes=""):
-    """Commit train.py changes with a descriptive message."""
+    """Stage and commit the current train.py to git with an informative message.
+
+    Only commits when there are actual staged changes to train.py.  Silently
+    returns False when git is unavailable or the working tree is not a repo.
+
+    Args:
+        model_name (str): Name of the model class used in this experiment
+            (e.g. "HistGradientBoostingRegressor").
+        val_score (float): Validation score achieved by this experiment.
+        metric_name (str): Name of the primary metric (e.g. "f1_weighted").
+        notes (str): Optional free-text notes to include in the commit body.
+
+    Returns:
+        bool: True if a commit was successfully created, False otherwise.
+    """
     try:
         # Check if git is available and we're in a repo
         check = subprocess.run(
@@ -194,7 +221,15 @@ def git_commit_train(model_name, val_score, metric_name, notes=""):
 
 
 def git_revert_train():
-    """Revert train.py to the last committed version."""
+    """Revert train.py to the last committed version via ``git checkout``.
+
+    Called when a training run does not improve the best validation score, so
+    the next experiment iteration starts from the last known-good model code.
+
+    Returns:
+        bool: True if the revert succeeded, False if git is unavailable or the
+            checkout command failed.
+    """
     try:
         result = subprocess.run(
             ["git", "checkout", "--", "src/train.py"],
@@ -213,7 +248,25 @@ def git_revert_train():
 
 def register_model_if_top_n(client, run_id, model_name, val_score,
                             experiment_name, top_n):
-    """Register model in MLflow registry and keep only the top N versions."""
+    """Register a model version in the MLflow Model Registry if it ranks in the top N.
+
+    The registry name is derived as ``agentml-<experiment_name>``.  After
+    registration, any versions beyond the top-N (by val_score) are deleted to
+    keep the registry tidy.
+
+    Args:
+        client (MlflowClient): Initialised MLflow tracking client.
+        run_id (str): MLflow run ID that produced the model artifact.
+        model_name (str): Human-readable model class name for the description.
+        val_score (float): Validation score used for ranking.
+        experiment_name (str): MLflow experiment name; determines the registry
+            name (``agentml-<experiment_name>``).
+        top_n (int): Maximum number of model versions to keep in the registry.
+
+    Returns:
+        bool: True if the model was registered, False if it did not qualify for
+            the top-N or if registration failed.
+    """
     registry_name = f"agentml-{experiment_name}"
 
     try:
@@ -286,7 +339,20 @@ def register_model_if_top_n(client, run_id, model_name, val_score,
 
 
 def print_summary(scores, train_result, improved):
-    """Print experiment summary."""
+    """Log a human-readable experiment summary and emit a strategy warning if needed.
+
+    Prints a formatted block with the current run's metrics alongside the
+    all-time best scores.  If three or more consecutive experiments have not
+    improved the best score, a warning is emitted suggesting config changes.
+
+    Args:
+        scores (dict): Current best-scores state as loaded/updated by
+            ``load_best_scores`` / ``save_best_scores``.
+        train_result (dict): Result dict returned by ``run_train``, containing
+            keys: ``model_name``, ``cv_mean``, ``cv_std``, ``val_score``,
+            ``training_time``.
+        improved (bool): Whether this run beat the previous best val_score.
+    """
     summary = (
         "\n" + "=" * 60 + "\n"
         "EXPERIMENT SUMMARY\n"

--- a/src/select_model.py
+++ b/src/select_model.py
@@ -24,7 +24,19 @@ from mlflow.tracking import MlflowClient
 
 
 def parse_program_md(path=None):
-    """Parse YAML frontmatter from program.md."""
+    """Parse the YAML frontmatter block from program.md.
+
+    program.md is delimited by ``---`` fences; this function extracts and
+    parses the YAML section between the first two ``---`` lines.
+
+    Args:
+        path (str, optional): Path to program.md.  Defaults to
+            ``<project_root>/program.md``.
+
+    Returns:
+        dict: Parsed configuration (MLflow URI, experiment name, etc.).
+            Returns an empty dict if no YAML frontmatter is found.
+    """
     if path is None:
         path = os.path.join(PROJECT_ROOT, "program.md")
     try:
@@ -49,7 +61,24 @@ def parse_program_md(path=None):
 
 
 def get_registered_models(client, registry_name):
-    """Get all registered model versions with their metrics, sorted by val_score."""
+    """Fetch all registered model versions and their performance metrics.
+
+    Queries the MLflow Model Registry for every version under ``registry_name``,
+    retrieves the associated run's metrics and params, and returns them sorted
+    by ``val_score`` descending (best first).
+
+    Args:
+        client (MlflowClient): Initialised MLflow tracking client.
+        registry_name (str): Registered model name to query
+            (e.g. ``"agentml-my_experiment"``).
+
+    Returns:
+        list[dict]: One dict per registered version with keys:
+            ``version``, ``run_id``, ``model_name``, ``val_score``,
+            ``cv_mean``, ``cv_std``, ``training_time``, ``status``,
+            ``current_stage``, ``description``.
+            Returns an empty list if no model is registered under that name.
+    """
     try:
         versions = client.search_model_versions(f"name='{registry_name}'")
     except mlflow.exceptions.MlflowException:
@@ -94,7 +123,17 @@ def get_registered_models(client, registry_name):
 
 
 def list_models(client, registry_name):
-    """Print a table of all registered models."""
+    """Log a ranked table of all registered model versions to the logger.
+
+    Outputs a formatted table sorted by validation score (best first) that
+    shows rank, registry version, model class name, val_score, CV mean/std,
+    and training time.  Logs a message and returns early if no models are
+    registered yet.
+
+    Args:
+        client (MlflowClient): Initialised MLflow tracking client.
+        registry_name (str): Registered model name to list.
+    """
     models = get_registered_models(client, registry_name)
 
     if not models:
@@ -122,10 +161,17 @@ def list_models(client, registry_name):
 
 
 def promote_model(client, registry_name, rank):
-    """Promote the model at the given rank to Production stage.
+    """Promote the model at the given rank to the MLflow Production stage.
 
-    Only one model version is in Production at a time: any existing
-    Production version is archived before the new one is promoted.
+    Models are ranked by ``val_score`` descending (rank 1 = best).  Any
+    existing Production version is archived first so that only one model is
+    in Production at a time.
+
+    Args:
+        client (MlflowClient): Initialised MLflow tracking client.
+        registry_name (str): Registered model name to operate on.
+        rank (int): 1-based rank of the model to promote.  Must be between
+            1 and the total number of registered versions.
     """
     models = get_registered_models(client, registry_name)
 

--- a/src/train.py
+++ b/src/train.py
@@ -35,7 +35,22 @@ from sklearn.metrics import (
 
 
 def load_data(path=None):
-    """Load preprocessed data splits."""
+    """Load the preprocessed data splits produced by prepare.py.
+
+    Args:
+        path (str, optional): Absolute path to the pickle file.  Defaults to
+            ``<project_root>/processed/data_splits.pkl``.
+
+    Returns:
+        dict: Data bundle with keys ``X_train``, ``y_train``, ``X_val``,
+            ``y_val``, ``X_test``, ``y_test``, ``feature_names``, and
+            ``metadata`` (task type, metric, encoder/scaler objects, etc.).
+
+    Raises:
+        FileNotFoundError: If the pickle file does not exist (prepare.py has
+            not been run yet).
+        RuntimeError: If the pickle file is corrupt or cannot be deserialised.
+    """
     if path is None:
         path = os.path.join(PROJECT_ROOT, "processed", "data_splits.pkl")
     try:
@@ -52,9 +67,16 @@ def load_data(path=None):
 
 
 def get_model(task_type):
-    """
-    Return the model to train.
-    The agent modifies this function to try different models and hyperparameters.
+    """Return the estimator to train for the given task type.
+
+    The AI agent modifies this function to explore different model families
+    and hyperparameter configurations across experiment iterations.
+
+    Args:
+        task_type (str): Either ``"classification"`` or ``"regression"``.
+
+    Returns:
+        sklearn estimator: An unfitted scikit-learn compatible model instance.
     """
     if task_type == "classification":
         from sklearn.ensemble import HistGradientBoostingClassifier
@@ -77,10 +99,19 @@ def get_model(task_type):
 
 
 def get_scoring(task_type, metric=None):
-    """Get the sklearn scoring string for cross-validation.
+    """Return the scikit-learn scoring string to use for cross-validation.
 
     Uses the metric from program.md if explicitly configured; otherwise
-    falls back to f1_weighted for classification and neg_RMSE for regression.
+    falls back to ``f1_weighted`` for classification and
+    ``neg_root_mean_squared_error`` for regression.
+
+    Args:
+        task_type (str): Either ``"classification"`` or ``"regression"``.
+        metric (str, optional): Metric name from program.md config.  Pass
+            ``None`` or ``"auto"`` to use the task-type default.
+
+    Returns:
+        str: A valid scikit-learn scoring string (e.g. ``"f1_weighted"``).
     """
     if metric and metric != "auto":
         return metric
@@ -91,11 +122,30 @@ def get_scoring(task_type, metric=None):
 
 
 def evaluate_model(model, X_val, y_val, task_type, metric_name="auto"):
-    """
-    Evaluate the trained model on the validation set.
-    Returns (primary_score, all_metrics_dict).
-    Primary score matches the configured metric for fair comparison.
-    All metrics are logged to MLflow for full visibility.
+    """Evaluate a fitted model on the held-out validation set.
+
+    Computes a full suite of metrics for the task type and selects the
+    *primary* score that matches the configured metric so that all
+    experiments are compared on the same basis.
+
+    Classification metrics computed: f1_weighted, accuracy,
+    precision_weighted, recall_weighted.
+
+    Regression metrics computed: RMSE, MAE, adjusted-R².
+
+    Args:
+        model: A fitted scikit-learn compatible estimator.
+        X_val (np.ndarray): Validation feature matrix.
+        y_val (np.ndarray): Validation target vector.
+        task_type (str): Either ``"classification"`` or ``"regression"``.
+        metric_name (str): Primary metric name (e.g. ``"f1_weighted"``,
+            ``"neg_root_mean_squared_error"``).  Defaults to ``"auto"``
+            which selects the task-type default.
+
+    Returns:
+        tuple[float, dict]: ``(primary_score, all_metrics)`` where
+            ``primary_score`` is the scalar used for experiment comparison
+            and ``all_metrics`` is a dict of all computed metric values.
     """
     y_pred = model.predict(X_val)
 


### PR DESCRIPTION
Adds Args/Returns/Raises sections and expands minimal one-liner docstrings for all public functions in run_experiment.py, train.py, and select_model.py. prepare.py is READ ONLY and already well-documented so was left unchanged.

Resolves #8

Generated with [Claude Code](https://claude.ai/code)